### PR TITLE
Add watershed, stream, basin, and DEM fill tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ This repository contains resources for the Google Earth Engine Hydro project. Ou
 - `fdr` – example script implementing the D8 flow direction algorithm.
 - `FlowDirectionLegend.png` – legend image describing direction codes.
 - `poster_dem_inspector.pdf` – research poster describing early work.
+- `flowacc.js` – compute flow accumulation within a drawn AOI.
+- `watershed.js` – delineate an upstream watershed from a pour point.
+- `streams.js` – derive a stream network from flow accumulation thresholds.
+- `basins.js` – generate drainage basins by propagating stream labels upstream.
+- `demfill.js` – fill DEM depressions to enforce drainage.
 
 ## Running the example
 

--- a/basins.js
+++ b/basins.js
@@ -1,0 +1,133 @@
+// Earth Engine basin generation from stream network
+
+// DEM options (first band used)
+var demList = {
+  'HydroSHEDS 03VFDEM': ee.Image('WWF/HydroSHEDS/03VFDEM'),
+  'JAXA AW3D30 (mosaic)': ee.ImageCollection('JAXA/ALOS/AW3D30/V4_1').mosaic(),
+  'NASA ASTER GED': ee.Image('NASA/ASTER_GED/AG100_003'),
+  'Copernicus GLO-30 (mosaic)': ee.ImageCollection('COPERNICUS/DEM/GLO30').mosaic(),
+  'USGS SRTMGL1': ee.Image('USGS/SRTMGL1_003'),
+  'USGS GTOPO30': ee.Image('USGS/GTOPO30'),
+  'NOAA ETOPO1': ee.Image('NOAA/NGDC/ETOPO1')
+};
+
+// D8 flow direction from a single-band DEM
+function D8Algorithm(dem) {
+  var band = ee.String(dem.bandNames().get(0));
+  var neighborhood = dem.neighborhoodToBands(ee.Kernel.square(1));
+  var center = neighborhood.select(band.cat('_0_0'));
+  var offsets = [
+    [-1, -1], [-1, 0], [-1, 1],
+    [ 0, -1],           [ 0, 1],
+    [ 1, -1], [ 1, 0],  [ 1, 1]
+  ];
+  var directions = [32, 64, 128, 16, 1, 8, 4, 2];
+  var distances = [Math.SQRT2, 1, Math.SQRT2, 1, 1, Math.SQRT2, 1, Math.SQRT2];
+  var maxSlope = ee.Image(-9999);
+  var flowDir = ee.Image(0).byte();
+  for (var i = 0; i < 8; i++) {
+    var row = offsets[i][0];
+    var col = offsets[i][1];
+    var bandName = band.cat('_').cat(ee.Number(row).format('%d')).cat('_').cat(ee.Number(col).format('%d'));
+    var neighbor = neighborhood.select(bandName);
+    var slope = center.subtract(neighbor).divide(distances[i]);
+    var dirImg = ee.Image.constant(directions[i]).byte();
+    var replace = slope.gt(maxSlope).and(slope.gt(0));
+    maxSlope = maxSlope.where(replace, slope);
+    flowDir = flowDir.where(replace, dirImg);
+  }
+  return flowDir.rename('flowDirection');
+}
+
+// Flow accumulation using an iterative D8 approach
+function flowAccumulation(flowDir, aoi, iterations) {
+  iterations = iterations || 100;
+  var acc = ee.Image.constant(1).rename('flowAccum');
+  var kernel = ee.Kernel.square(1);
+  var offsets = [
+    [-1, -1], [-1, 0], [-1, 1],
+    [ 0, -1],           [ 0, 1],
+    [ 1, -1], [ 1, 0],  [ 1, 1]
+  ];
+  var inflowDir = [2, 4, 8, 1, 16, 128, 64, 32];
+  for (var step = 0; step < iterations; step++) {
+    var accNeigh = acc.neighborhoodToBands(kernel);
+    var dirNeigh = flowDir.neighborhoodToBands(kernel);
+    var contrib = ee.Image(0);
+    for (var j = 0; j < 8; j++) {
+      var row = offsets[j][0];
+      var col = offsets[j][1];
+      var dirBand = 'flowDirection_' + row + '_' + col;
+      var accBand = 'flowAccum_' + row + '_' + col;
+      var mask = dirNeigh.select(dirBand).eq(inflowDir[j]);
+      contrib = contrib.add(accNeigh.select(accBand).updateMask(mask));
+    }
+    acc = acc.add(contrib);
+  }
+  return acc.clip(aoi);
+}
+
+// Propagate unique stream labels upstream to form basins
+function generateBasins(flowDir, streams, iterations) {
+  iterations = iterations || 100;
+  var labels = streams.mask().connectedComponents(ee.Kernel.plus(1), 256).rename('basin');
+  var basins = labels.unmask(0);
+  var kernel = ee.Kernel.square(1);
+  var offsets = [
+    [-1, -1], [-1, 0], [-1, 1],
+    [ 0, -1],           [ 0, 1],
+    [ 1, -1], [ 1, 0],  [ 1, 1]
+  ];
+  var inflowDir = [2, 4, 8, 1, 16, 128, 64, 32];
+  for (var step = 0; step < iterations; step++) {
+    var basinNeigh = basins.neighborhoodToBands(kernel);
+    var dirNeigh = flowDir.neighborhoodToBands(kernel);
+    var newPix = ee.Image(0);
+    for (var j = 0; j < 8; j++) {
+      var row = offsets[j][0];
+      var col = offsets[j][1];
+      var dirBand = 'flowDirection_' + row + '_' + col;
+      var basinBand = 'basin_' + row + '_' + col;
+      var mask = dirNeigh.select(dirBand).eq(inflowDir[j]);
+      var contrib = basinNeigh.select(basinBand).updateMask(mask);
+      newPix = newPix.where(contrib.neq(0), contrib);
+    }
+    basins = basins.where(newPix.neq(0).and(basins.eq(0)), newPix);
+  }
+  return basins;
+}
+
+// UI elements
+var demNames = Object.keys(demList);
+var demSelect = ui.Select({items: demNames, value: demNames[0]});
+var threshold = ui.Slider({min: 100, max: 10000, value: 1000, step: 100, style: {stretch: 'horizontal'}});
+var runBtn = ui.Button('Generate Basins');
+var panel = ui.Panel([
+  ui.Label('Select DEM:'), demSelect,
+  ui.Label('Flow accumulation threshold:'), threshold,
+  ui.Label('Draw an AOI polygon then click the button.'),
+  runBtn
+]);
+panel.style().set({position: 'top-right', width: '300px'});
+ui.root.add(panel);
+
+Map.drawingTools().setDrawModes(['polygon']);
+Map.drawingTools().draw();
+
+runBtn.onClick(function() {
+  var layers = Map.drawingTools().layers();
+  if (layers.length() === 0) {
+    ui.alert('Please draw an AOI polygon.');
+    return;
+  }
+  var aoi = ee.Feature(layers.get(0)).geometry();
+  var dem = demList[demSelect.getValue()];
+  var fdir = D8Algorithm(dem);
+  var acc = flowAccumulation(fdir, aoi, 100);
+  var streams = acc.gte(threshold.getValue());
+  var basins = generateBasins(fdir, streams, 100);
+  Map.clear();
+  Map.addLayer(basins.randomVisualizer(), {}, 'Basins');
+  Map.addLayer(streams.selfMask(), {palette: ['0000ff']}, 'Streams');
+  Map.addLayer(aoi, {color: 'red'}, 'AOI');
+});

--- a/demfill.js
+++ b/demfill.js
@@ -1,0 +1,35 @@
+// Earth Engine DEM depression filling demonstration
+
+// DEM options (first band used)
+var demList = {
+  'HydroSHEDS 03VFDEM': ee.Image('WWF/HydroSHEDS/03VFDEM'),
+  'JAXA AW3D30 (mosaic)': ee.ImageCollection('JAXA/ALOS/AW3D30/V4_1').mosaic(),
+  'NASA ASTER GED': ee.Image('NASA/ASTER_GED/AG100_003'),
+  'Copernicus GLO-30 (mosaic)': ee.ImageCollection('COPERNICUS/DEM/GLO30').mosaic(),
+  'USGS SRTMGL1': ee.Image('USGS/SRTMGL1_003'),
+  'USGS GTOPO30': ee.Image('USGS/GTOPO30'),
+  'NOAA ETOPO1': ee.Image('NOAA/NGDC/ETOPO1')
+};
+
+// UI elements
+var demNames = Object.keys(demList);
+var demSelect = ui.Select({items: demNames, value: demNames[0]});
+var runBtn = ui.Button('Fill DEM Depressions');
+var panel = ui.Panel([
+  ui.Label('Select DEM:'), demSelect,
+  ui.Label('Click the button to compute a pit-filled DEM.'),
+  runBtn
+]);
+panel.style().set({position: 'top-right'});
+ui.root.add(panel);
+
+runBtn.onClick(function() {
+  var dem = demList[demSelect.getValue()];
+  // Fill depressions to enforce drainage
+  var filled = ee.Algorithms.Hydrology.fill(dem);
+  var depth = filled.subtract(dem);
+  Map.clear();
+  Map.addLayer(dem, {min: 0, max: 3000, palette: ['ffffff', '000000']}, 'Original DEM');
+  Map.addLayer(filled, {min: 0, max: 3000, palette: ['ffffff', '0000ff']}, 'Filled DEM');
+  Map.addLayer(depth.selfMask(), {min: 0, max: 50, palette: ['ffff00', 'ff0000']}, 'Fill Depth');
+});

--- a/logs/AGENTS.md
+++ b/logs/AGENTS.md
@@ -2,3 +2,4 @@
 
 Record all changes, ideas, and relevant context here. Each agent should append a short entry describing what they did and any future considerations.
 - Added flow accumulation script using D8 directions and AOI drawing.
+- Added watershed delineation, stream extraction, basin generation, and DEM fill scripts.

--- a/streams.js
+++ b/streams.js
@@ -1,0 +1,102 @@
+// Earth Engine stream extraction from flow accumulation
+
+// DEM options (first band used)
+var demList = {
+  'HydroSHEDS 03VFDEM': ee.Image('WWF/HydroSHEDS/03VFDEM'),
+  'JAXA AW3D30 (mosaic)': ee.ImageCollection('JAXA/ALOS/AW3D30/V4_1').mosaic(),
+  'NASA ASTER GED': ee.Image('NASA/ASTER_GED/AG100_003'),
+  'Copernicus GLO-30 (mosaic)': ee.ImageCollection('COPERNICUS/DEM/GLO30').mosaic(),
+  'USGS SRTMGL1': ee.Image('USGS/SRTMGL1_003'),
+  'USGS GTOPO30': ee.Image('USGS/GTOPO30'),
+  'NOAA ETOPO1': ee.Image('NOAA/NGDC/ETOPO1')
+};
+
+// D8 flow direction from a single-band DEM
+function D8Algorithm(dem) {
+  var band = ee.String(dem.bandNames().get(0));
+  var neighborhood = dem.neighborhoodToBands(ee.Kernel.square(1));
+  var center = neighborhood.select(band.cat('_0_0'));
+  var offsets = [
+    [-1, -1], [-1, 0], [-1, 1],
+    [ 0, -1],           [ 0, 1],
+    [ 1, -1], [ 1, 0],  [ 1, 1]
+  ];
+  var directions = [32, 64, 128, 16, 1, 8, 4, 2];
+  var distances = [Math.SQRT2, 1, Math.SQRT2, 1, 1, Math.SQRT2, 1, Math.SQRT2];
+  var maxSlope = ee.Image(-9999);
+  var flowDir = ee.Image(0).byte();
+  for (var i = 0; i < 8; i++) {
+    var row = offsets[i][0];
+    var col = offsets[i][1];
+    var bandName = band.cat('_').cat(ee.Number(row).format('%d')).cat('_').cat(ee.Number(col).format('%d'));
+    var neighbor = neighborhood.select(bandName);
+    var slope = center.subtract(neighbor).divide(distances[i]);
+    var dirImg = ee.Image.constant(directions[i]).byte();
+    var replace = slope.gt(maxSlope).and(slope.gt(0));
+    maxSlope = maxSlope.where(replace, slope);
+    flowDir = flowDir.where(replace, dirImg);
+  }
+  return flowDir.rename('flowDirection');
+}
+
+// Flow accumulation using an iterative D8 approach
+function flowAccumulation(flowDir, aoi, iterations) {
+  iterations = iterations || 100;
+  var acc = ee.Image.constant(1).rename('flowAccum');
+  var kernel = ee.Kernel.square(1);
+  var offsets = [
+    [-1, -1], [-1, 0], [-1, 1],
+    [ 0, -1],           [ 0, 1],
+    [ 1, -1], [ 1, 0],  [ 1, 1]
+  ];
+  var inflowDir = [2, 4, 8, 1, 16, 128, 64, 32];
+  for (var step = 0; step < iterations; step++) {
+    var accNeigh = acc.neighborhoodToBands(kernel);
+    var dirNeigh = flowDir.neighborhoodToBands(kernel);
+    var contrib = ee.Image(0);
+    for (var j = 0; j < 8; j++) {
+      var row = offsets[j][0];
+      var col = offsets[j][1];
+      var dirBand = 'flowDirection_' + row + '_' + col;
+      var accBand = 'flowAccum_' + row + '_' + col;
+      var mask = dirNeigh.select(dirBand).eq(inflowDir[j]);
+      contrib = contrib.add(accNeigh.select(accBand).updateMask(mask));
+    }
+    acc = acc.add(contrib);
+  }
+  return acc.clip(aoi);
+}
+
+// UI elements
+var demNames = Object.keys(demList);
+var demSelect = ui.Select({items: demNames, value: demNames[0]});
+var threshold = ui.Slider({min: 100, max: 10000, value: 1000, step: 100, style: {stretch: 'horizontal'}});
+var runBtn = ui.Button('Extract Streams');
+var panel = ui.Panel([
+  ui.Label('Select DEM:'), demSelect,
+  ui.Label('Flow accumulation threshold:'), threshold,
+  ui.Label('Draw an AOI polygon then click the button.'),
+  runBtn
+]);
+panel.style().set({position: 'top-right', width: '300px'});
+ui.root.add(panel);
+
+Map.drawingTools().setDrawModes(['polygon']);
+Map.drawingTools().draw();
+
+runBtn.onClick(function() {
+  var layers = Map.drawingTools().layers();
+  if (layers.length() === 0) {
+    ui.alert('Please draw an AOI polygon.');
+    return;
+  }
+  var aoi = ee.Feature(layers.get(0)).geometry();
+  var dem = demList[demSelect.getValue()];
+  var fdir = D8Algorithm(dem);
+  var acc = flowAccumulation(fdir, aoi, 100);
+  var streams = acc.gte(threshold.getValue());
+  Map.clear();
+  Map.addLayer(acc.log10(), {min: 0, max: 5, palette: ['ffffff', '0000ff']}, 'Flow Accumulation (log10)');
+  Map.addLayer(streams.selfMask(), {palette: ['00ff00']}, 'Streams');
+  Map.addLayer(aoi, {color: 'red'}, 'AOI');
+});

--- a/watershed.js
+++ b/watershed.js
@@ -1,0 +1,103 @@
+// Earth Engine watershed delineation using D8 flow directions
+
+// DEM options (first band used)
+var demList = {
+  'HydroSHEDS 03VFDEM': ee.Image('WWF/HydroSHEDS/03VFDEM'),
+  'JAXA AW3D30 (mosaic)': ee.ImageCollection('JAXA/ALOS/AW3D30/V4_1').mosaic(),
+  'NASA ASTER GED': ee.Image('NASA/ASTER_GED/AG100_003'),
+  'Copernicus GLO-30 (mosaic)': ee.ImageCollection('COPERNICUS/DEM/GLO30').mosaic(),
+  'USGS SRTMGL1': ee.Image('USGS/SRTMGL1_003'),
+  'USGS GTOPO30': ee.Image('USGS/GTOPO30'),
+  'NOAA ETOPO1': ee.Image('NOAA/NGDC/ETOPO1')
+};
+
+// Compute D8 flow direction from a single-band DEM
+// Returns byte image with D8 codes (1,2,4,8,16,32,64,128)
+function D8Algorithm(dem) {
+  var band = ee.String(dem.bandNames().get(0));
+  var neighborhood = dem.neighborhoodToBands(ee.Kernel.square(1));
+  var center = neighborhood.select(band.cat('_0_0'));
+
+  var offsets = [
+    [-1, -1], [-1, 0], [-1, 1],
+    [ 0, -1],           [ 0, 1],
+    [ 1, -1], [ 1, 0],  [ 1, 1]
+  ];
+  var directions = [32, 64, 128, 16, 1, 8, 4, 2];
+  var distances = [Math.SQRT2, 1, Math.SQRT2, 1, 1, Math.SQRT2, 1, Math.SQRT2];
+
+  var maxSlope = ee.Image(-9999);
+  var flowDir = ee.Image(0).byte();
+
+  for (var i = 0; i < 8; i++) {
+    var row = offsets[i][0];
+    var col = offsets[i][1];
+    var bandName = band.cat('_').cat(ee.Number(row).format('%d')).cat('_').cat(ee.Number(col).format('%d'));
+    var neighbor = neighborhood.select(bandName);
+    var slope = center.subtract(neighbor).divide(distances[i]);
+    var dirImg = ee.Image.constant(directions[i]).byte();
+    var replace = slope.gt(maxSlope).and(slope.gt(0));
+    maxSlope = maxSlope.where(replace, slope);
+    flowDir = flowDir.where(replace, dirImg);
+  }
+  return flowDir.rename('flowDirection');
+}
+
+// Delineate watershed upstream of a pour point using D8 directions
+function delineateWatershed(flowDir, pourPoint, iterations) {
+  iterations = iterations || 100;
+  var ws = pourPoint.rename('watershed');
+  var kernel = ee.Kernel.square(1);
+  var offsets = [
+    [-1, -1], [-1, 0], [-1, 1],
+    [ 0, -1],           [ 0, 1],
+    [ 1, -1], [ 1, 0],  [ 1, 1]
+  ];
+  var inflowDir = [2, 4, 8, 1, 16, 128, 64, 32];
+  for (var step = 0; step < iterations; step++) {
+    var wsNeigh = ws.neighborhoodToBands(kernel);
+    var dirNeigh = flowDir.neighborhoodToBands(kernel);
+    var newPix = ee.Image(0);
+    for (var j = 0; j < 8; j++) {
+      var row = offsets[j][0];
+      var col = offsets[j][1];
+      var dirBand = 'flowDirection_' + row + '_' + col;
+      var wsBand = 'watershed_' + row + '_' + col;
+      var mask = dirNeigh.select(dirBand).eq(inflowDir[j]);
+      newPix = newPix.or(wsNeigh.select(wsBand).and(mask));
+    }
+    ws = ws.or(newPix.rename('watershed'));
+  }
+  return ws;
+}
+
+// UI elements
+var demNames = Object.keys(demList);
+var demSelect = ui.Select({items: demNames, value: demNames[0]});
+var runBtn = ui.Button('Delineate Watershed');
+var panel = ui.Panel([
+  ui.Label('Select DEM:'), demSelect,
+  ui.Label('Draw a pour point then click the button.'),
+  runBtn
+]);
+panel.style().set({position: 'top-right'});
+ui.root.add(panel);
+
+Map.drawingTools().setDrawModes(['point']);
+Map.drawingTools().draw();
+
+runBtn.onClick(function() {
+  var layers = Map.drawingTools().layers();
+  if (layers.length() === 0) {
+    ui.alert('Please draw a pour point.');
+    return;
+  }
+  var pt = ee.Feature(layers.get(0)).geometry();
+  var dem = demList[demSelect.getValue()];
+  var fdir = D8Algorithm(dem);
+  var pourImg = ee.Image().byte().paint(pt, 1);
+  var ws = delineateWatershed(fdir, pourImg, 100);
+  Map.clear();
+  Map.addLayer(ws.selfMask(), {palette: ['0000ff']}, 'Watershed');
+  Map.addLayer(pt, {color: 'red'}, 'Pour Point');
+});


### PR DESCRIPTION
## Summary
- Add watershed delineation script leveraging D8 flow directions and pour point inputs
- Add stream extraction script using flow accumulation threshold and AOI drawing
- Add basin generation script that propagates stream labels upstream
- Add DEM depression filling demonstration script
- Document new scripts in README and update agent work log

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_689fa9bf36b4832789e68418edbf8ff1